### PR TITLE
Added new default line clear animations using easing functions.

### DIFF
--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -598,11 +598,28 @@ function GameMode:getHighScoreData()
 end
 
 function GameMode:animation(x, y, skin, colour)
+	-- Animation progress where 0 = start and 1 = end
+	local progress = 1
+	if self.last_lcd ~= 0 then
+		progress = (self.last_lcd - self.lcd) / self.last_lcd
+	end
+	-- Change this number to change "bounciness"
+	local bounce = 13
+	-- Convert progress through the animation into an alpha value
+	local alpha = 0
+	-- Cutoff is arbitrary: corresponds to level 500 in Marathon A2
+	if self.last_lcd > 25 then
+		-- Goes up and down: looks better when animation is long
+		alpha = 1 - (bounce * progress^3 - 1.5 * bounce * progress^2 + (0.5 * bounce + 1) * progress)
+	else
+		-- Always decreasing: looks better when animation is short
+		alpha = 1 - progress * progress
+	end
 	return {
-		1, 1, 1,
-		-0.25 + 1.25 * (self.lcd / self.last_lcd),
-		skin, colour,
-		48 + x * 16, y * 16
+			1, 1, 1,
+			alpha,
+			skin, colour,
+			48 + x * 16, y * 16
 	}
 end
 
@@ -614,8 +631,37 @@ function GameMode:drawLineClearAnimation()
 	-- animation function
 	-- params: block x, y, skin, colour
 	-- returns: table with RGBA, skin, colour, x, y
-	
-	-- Fadeout (default)
+
+	-- Flashy Fadeout (default)
+	--[[
+	function animation(x, y, skin, colour)
+		-- Animation progress where 0 = start and 1 = end
+		local progress = 1
+		if self.last_lcd ~= 0 then
+			progress = (self.last_lcd - self.lcd) / self.last_lcd
+		end
+		-- Change this number to change "bounciness"
+		local bounce = 13
+		-- Convert progress through the animation into an alpha value
+		local alpha = 0
+		-- Cutoff is arbitrary: corresponds to level 500 in Marathon A2
+		if self.last_lcd > 25 then
+			-- Goes up and down: looks better when animation is long
+			alpha = 1 - (bounce * progress^3 - 1.5 * bounce * progress^2 + (0.5 * bounce + 1) * progress)
+		else
+			-- Always decreasing: looks better when animation is short
+			alpha = 1 - progress * progress
+		end
+		return {
+				1, 1, 1,
+				alpha,
+				skin, colour,
+				48 + x * 16, y * 16
+		}
+	end
+	--]]
+
+	-- Fadeout
 	--[[
 	function animation(x, y, skin, colour)
 		return {


### PR DESCRIPTION
I thought a juicier line clear animation would be fun.
When the line clear delay is long, alpha is adjusted using a cubic function that goes up and down before fading out.
It doesn't look great at higher speeds, so when lock delay is short, a simple quadratic is used instead. It's close to the old linear fadeout, but slightly more juicy at medium speeds.
I chose 25 frames as the cutoff: the line clear delay at level 500 in A2 Marathon.
Video of the new animations in A2 marathon level 0 and A2 Survival level 0 here https://youtu.be/42Bd0YLMOtM