### PR TITLE
Game over fadeout easing function now accelerates

### DIFF
--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -612,18 +612,8 @@ function GameMode:animation(x, y, skin, colour)
 	if self.last_lcd ~= 0 then
 		progress = (self.last_lcd - self.lcd) / self.last_lcd
 	end
-	-- Change this number to change "bounciness"
-	local bounce = 13
-	-- Convert progress through the animation into an alpha value
-	local alpha = 0
-	-- Cutoff is arbitrary: corresponds to level 500 in Marathon A2
-	if self.last_lcd > 25 then
-		-- Goes up and down: looks better when animation is long
-		alpha = 1 - (bounce * progress^3 - 1.5 * bounce * progress^2 + (0.5 * bounce + 1) * progress)
-	else
-		-- Always decreasing: looks better when animation is short
-		alpha = 1 - progress * progress
-	end
+	-- Convert progress through the animation into an alpha value, with easing
+	local alpha = 1 - progress ^ 2
 	return {
 			1, 1, 1,
 			alpha,
@@ -641,7 +631,26 @@ function GameMode:drawLineClearAnimation()
 	-- params: block x, y, skin, colour
 	-- returns: table with RGBA, skin, colour, x, y
 
-	-- Flashy Fadeout (default)
+	-- Quadratic Fadeout (default)
+	--[[
+	function animation(x, y, skin, colour)
+		-- Animation progress where 0 = start and 1 = end
+		local progress = 1
+		if self.last_lcd ~= 0 then
+			progress = (self.last_lcd - self.lcd) / self.last_lcd
+		end
+		-- Convert progress through the animation into an alpha value, with easing
+		local alpha = 1 - progress ^ 2
+		return {
+				1, 1, 1,
+				alpha,
+				skin, colour,
+				48 + x * 16, y * 16
+		}
+	end
+	--]]
+
+	-- Flashy Fadeout
 	--[[
 	function animation(x, y, skin, colour)
 		-- Animation progress where 0 = start and 1 = end

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -334,10 +334,14 @@ end
 
 function GameMode:onGameOver()
 	switchBGM(nil)
-	local alpha = 1
-	local animation_length = 90
+	local alpha = 0
+	local animation_length = 120
 	if self.game_over_frames < animation_length then
+		-- Show field for a bit, then fade out.
 		alpha = math.pow(2048, self.game_over_frames/animation_length - 1)
+	elseif self.game_over_frames < 2 * animation_length then
+		-- Keep field hidden for a short time, then pop it back in (for screenshots).
+		alpha = 1
 	end
 	love.graphics.setColor(0, 0, 0, alpha)
 	love.graphics.rectangle(

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -334,7 +334,12 @@ end
 
 function GameMode:onGameOver()
 	switchBGM(nil)
-	love.graphics.setColor(0, 0, 0, 1 - 2 ^ (-self.game_over_frames / 30))
+	local alpha = 1
+	local animation_length = 90
+	if self.game_over_frames < animation_length then
+		alpha = math.pow(2048, self.game_over_frames/animation_length - 1)
+	end
+	love.graphics.setColor(0, 0, 0, alpha)
 	love.graphics.rectangle(
 		"fill", 64, 80,
 		16 * self.grid.width, 16 * (self.grid.height - 4)


### PR DESCRIPTION
The old easing function decelerates. This is what the new one looks like as of the first commit: https://youtu.be/DQV6WwaWv74
Second commit lengthens the animation a little and pops the board back in afterwards.
Third commit changes the default line clear animation easing function to be the same at all speeds.