### PR TITLE
Added replays

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -35,6 +35,8 @@ function love.load()
 end
 
 function initModules()
+	-- replays are not loaded here, but they are cleared
+	replays = {}
 	game_modes = {}
 	mode_list = love.filesystem.getDirectoryItems("tetris/modes")
 	for i=1,#mode_list do

--- a/scene.lua
+++ b/scene.lua
@@ -10,7 +10,9 @@ function Scene:onInputRelease() end
 
 ExitScene = require "scene.exit"
 GameScene = require "scene.game"
+ReplayScene = require "scene.replay"
 ModeSelectScene = require "scene.mode_select"
+ReplaySelectScene = require "scene.replay_select"
 KeyConfigScene = require "scene.key_config"
 StickConfigScene = require "scene.stick_config"
 InputConfigScene = require "scene.input_config"

--- a/scene/replay.lua
+++ b/scene/replay.lua
@@ -2,10 +2,65 @@ local ReplayScene = Scene:extend()
 
 ReplayScene.title = "Replay"
 
-require 'load.save'
+function ReplayScene:new(replay, game_mode, ruleset, inputs)
+	self.secret_inputs = inputs
+	self.game = game_mode(self.secret_inputs)
+	self.ruleset = ruleset(self.game)
+	self.game:initialize(self.ruleset)
+	self.inputs = {
+		left=false,
+		right=false,
+		up=false,
+		down=false,
+		rotate_left=false,
+		rotate_left2=false,
+		rotate_right=false,
+		rotate_right2=false,
+		rotate_180=false,
+		hold=false,
+	}
+	self.paused = false
+	self.replay = replay
+	self.replay_index = 1
+	DiscordRPC:update({
+		details = self.game.rpc_details,
+		state = self.game.name,
+		largeImageKey = "ingame-"..self.game:getBackground().."00"
+	})
+end
 
-function ReplayScene:new(replay, inputs)
-	-- TODO
+function ReplayScene:update()
+	if love.window.hasFocus() and not self.paused then
+		self.inputs = self.replay["inputs"][self.replay_index]["inputs"]
+		self.replay["inputs"][self.replay_index]["frames"] = self.replay["inputs"][self.replay_index]["frames"] - 1
+		if self.replay["inputs"][self.replay_index]["frames"] == 0 and self.replay_index < table.getn(self.replay["inputs"]) then
+			self.replay_index = self.replay_index + 1
+		end
+		local input_copy = {}
+		for input, value in pairs(self.inputs) do
+			input_copy[input] = value
+		end
+		self.game:update(input_copy, self.ruleset)
+		self.game.grid:update()
+		DiscordRPC:update({
+			largeImageKey = "ingame-"..self.game:getBackground().."00"
+		})
+	end
+end
+
+function ReplayScene:render()
+	self.game:draw(self.paused)
+end
+
+function ReplayScene:onInputPress(e)
+	if (e.input == "menu_back") then
+		self.game:onExit()
+		scene = ReplaySelectScene()
+	elseif e.input == "pause" and not (self.game.game_over or self.game.completed) then
+		self.paused = not self.paused
+		if self.paused then pauseBGM()
+		else resumeBGM() end
+	end
 end
 
 return ReplayScene

--- a/scene/replay.lua
+++ b/scene/replay.lua
@@ -1,3 +1,5 @@
+local Sequence = require 'tetris.randomizers.fixed_sequence'
+
 local ReplayScene = Scene:extend()
 
 ReplayScene.title = "Replay"
@@ -6,7 +8,10 @@ function ReplayScene:new(replay, game_mode, ruleset, inputs)
 	self.secret_inputs = inputs
 	self.game = game_mode(self.secret_inputs)
 	self.ruleset = ruleset(self.game)
-	self.game:initialize(self.ruleset)
+	-- Replace piece randomizer with replay piece sequence
+	local randomizer = Sequence(table.keys(ruleset.colourscheme))
+	randomizer.sequence = replay["pieces"]
+	self.game:initializeReplay(self.ruleset, randomizer)
 	self.inputs = {
 		left=false,
 		right=false,

--- a/scene/replay.lua
+++ b/scene/replay.lua
@@ -1,0 +1,11 @@
+local ReplayScene = Scene:extend()
+
+ReplayScene.title = "Replay"
+
+require 'load.save'
+
+function ReplayScene:new(replay, inputs)
+	-- TODO
+end
+
+return ReplayScene

--- a/scene/replay_select.lua
+++ b/scene/replay_select.lua
@@ -129,7 +129,13 @@ function ReplaySelectScene:render()
 	love.graphics.setFont(font_3x5_2)
 	for idx, replay in ipairs(replays) do
 		if(idx >= self.menu_state.replay-9 and idx <= self.menu_state.replay+9) then
-			local display_string = os.date("%c", replay["timestamp"]).."  "..replay["mode"].."  "..replay["ruleset"].."  Level: "..replay["level"].."  Time: "..formatTime(replay["timer"])
+			local display_string = os.date("%c", replay["timestamp"]).."  "..replay["mode"].."  "..replay["ruleset"]
+			if replay["level"] ~= nil then
+				display_string = display_string.."  Level: "..replay["level"]
+			end
+			if replay["timer"] ~= nil then
+				display_string = display_string.."  Time: "..formatTime(replay["timer"])
+			end
 			love.graphics.printf(display_string, 6, (260 - 20*(self.menu_state.replay)) + 20 * idx, 640, "left")
 		end
 	end

--- a/scene/replay_select.lua
+++ b/scene/replay_select.lua
@@ -13,7 +13,9 @@ function ReplaySelectScene:new()
 	replays = {}
 	replay_file_list = love.filesystem.getDirectoryItems("replays")
 	for i=1,#replay_file_list do
-		replays[i] = binser.deserialize(love.filesystem.read("replays/"..replay_file_list[i]))
+		local data = love.filesystem.read("replays/"..replay_file_list[i])
+		local object = binser.deserialize(data)
+		replays[i] = object[1]
 	end
 	-- TODO sort replays list
 	if table.getn(replays) == 0 then
@@ -85,13 +87,14 @@ function ReplaySelectScene:render()
 	end
 
 	love.graphics.setColor(1, 1, 1, 0.5)
-	love.graphics.rectangle("fill", 20, 258, 240, 22)
+	love.graphics.rectangle("fill", 20, 258, 500, 22)
 
 	love.graphics.setFont(font_3x5_2)
 	for idx, replay in pairs(replays) do
 		if(idx >= self.menu_state.replay-9 and idx <= self.menu_state.replay+9) then
+			-- TODO format timer into minutes:seconds:centiseconds
 			local display_string = replay["mode"].." "..replay["ruleset"].." "..replay["timer"].." "..replay["level"].." "..os.date("%c", replay["timestamp"])
-			love.graphics.printf(display_string, 40, (260 - 20*(self.menu_state.replay)) + 20 * idx, 200, "left")
+			love.graphics.printf(display_string, 40, (260 - 20*(self.menu_state.replay)) + 20 * idx, 500, "left")
 		end
 	end
 end

--- a/scene/replay_select.lua
+++ b/scene/replay_select.lua
@@ -14,10 +14,26 @@ function ReplaySelectScene:new()
 	replay_file_list = love.filesystem.getDirectoryItems("replays")
 	for i=1,#replay_file_list do
 		local data = love.filesystem.read("replays/"..replay_file_list[i])
-		local object = binser.deserialize(data)
-		replays[i] = object[1]
+		local new_replay = binser.deserialize(data)[1]
+		-- Insert, sorting by date played, newest first
+		local start_index, mid_index, end_index = 1, 1, i
+		if i ~= 1 then
+			while start_index <= end_index do
+				mid_index = math.floor((start_index + end_index) / 2)
+				print(start_index, mid_index, end_index)
+				print(replays[mid_index])
+				print(new_replay)
+				if os.difftime(replays[mid_index]["timestamp"], new_replay["timestamp"]) <= 0 then
+					-- search first half
+					end_index = mid_index - 1
+				else
+					-- search second half
+					start_index = mid_index + 1
+				end
+			end
+		end
+		table.insert(replays, mid_index, new_replay)
 	end
-	-- TODO sort replays list
 	if table.getn(replays) == 0 then
 		self.display_warning = true
 		current_replay = 1
@@ -87,14 +103,13 @@ function ReplaySelectScene:render()
 	end
 
 	love.graphics.setColor(1, 1, 1, 0.5)
-	love.graphics.rectangle("fill", 20, 258, 500, 22)
+	love.graphics.rectangle("fill", 3, 258, 634, 22)
 
 	love.graphics.setFont(font_3x5_2)
-	for idx, replay in pairs(replays) do
+	for idx, replay in ipairs(replays) do
 		if(idx >= self.menu_state.replay-9 and idx <= self.menu_state.replay+9) then
-			-- TODO format timer into minutes:seconds:centiseconds
-			local display_string = replay["mode"].." "..replay["ruleset"].." "..replay["timer"].." "..replay["level"].." "..os.date("%c", replay["timestamp"])
-			love.graphics.printf(display_string, 40, (260 - 20*(self.menu_state.replay)) + 20 * idx, 500, "left")
+			local display_string = os.date("%c", replay["timestamp"]).."  "..replay["mode"].."  "..replay["ruleset"].."  Level: "..replay["level"].."  Time: "..formatTime(replay["timer"])
+			love.graphics.printf(display_string, 6, (260 - 20*(self.menu_state.replay)) + 20 * idx, 640, "left")
 		end
 	end
 end

--- a/scene/replay_select.lua
+++ b/scene/replay_select.lua
@@ -1,0 +1,148 @@
+local ReplaySelectScene = Scene:extend()
+
+ReplaySelectScene.title = "Replays"
+
+local binser = require 'libs.binser'
+
+current_replay = 1
+
+function ReplaySelectScene:new()
+	-- reload custom modules
+	initModules()
+	-- load replays
+	replays = {}
+	replay_file_list = love.filesystem.getDirectoryItems("replays")
+	for i=1,#replay_file_list do
+		replays[i] = binser.deserialize(love.filesystem.read("replays/"..replay_file_list[i]))
+	end
+	-- TODO sort replays list
+	if table.getn(replays) == 0 then
+		self.display_warning = true
+		current_replay = 1
+	else
+		self.display_warning = false
+		if current_replay > table.getn(replays) then
+			current_replay = 1
+		end
+	end
+
+	self.menu_state = {
+		replay = current_replay,
+	}
+	self.secret_inputs = {}
+	self.das = 0
+	DiscordRPC:update({
+		details = "In menus",
+		state = "Choosing a replay",
+		largeImageKey = "ingame-000"
+	})
+end
+
+function ReplaySelectScene:update()
+	switchBGM(nil) -- experimental
+
+	if self.das_up or self.das_down then
+		self.das = self.das + 1
+	else
+		self.das = 0
+	end
+
+	if self.das >= 15 then
+		self:changeOption(self.das_up and -1 or 1)
+		self.das = self.das - 4
+	end
+
+	DiscordRPC:update({
+		details = "In menus",
+		state = "Choosing a replay",
+		largeImageKey = "ingame-000"
+	})
+end
+
+function ReplaySelectScene:render()
+	love.graphics.draw(
+		backgrounds[0],
+		0, 0, 0,
+		0.5, 0.5
+	)
+
+	-- Same graphic as mode select
+	love.graphics.draw(misc_graphics["select_mode"], 20, 40)
+
+	if self.display_warning then
+		love.graphics.setFont(font_3x5_3)
+		love.graphics.printf(
+			"You have no replays.",
+			80, 200, 480, "center"
+		)
+		love.graphics.setFont(font_3x5_2)
+		love.graphics.printf(
+			"Come back to this menu after playing some games. " ..
+			"Press any button to return to the main menu.",
+			80, 250, 480, "center"
+		)
+		return
+	end
+
+	love.graphics.setColor(1, 1, 1, 0.5)
+	love.graphics.rectangle("fill", 20, 258, 240, 22)
+
+	love.graphics.setFont(font_3x5_2)
+	for idx, replay in pairs(replays) do
+		if(idx >= self.menu_state.replay-9 and idx <= self.menu_state.replay+9) then
+			local display_string = replay["mode"].." "..replay["ruleset"].." "..replay["timer"].." "..replay["level"].." "..os.date("%c", replay["timestamp"])
+			love.graphics.printf(display_string, 40, (260 - 20*(self.menu_state.replay)) + 20 * idx, 200, "left")
+		end
+	end
+end
+
+function ReplaySelectScene:onInputPress(e)
+	if self.display_warning and e.input then
+		scene = TitleScene()
+	elseif e.type == "wheel" then
+		if e.x % 2 == 1 then
+			self:switchSelect()
+		end
+		if e.y ~= 0 then
+			self:changeOption(-e.y)
+		end
+	elseif e.input == "menu_decide" or e.scancode == "return" then
+		current_replay = self.menu_state.replay
+		-- Same as mode decide
+		playSE("mode_decide")
+		scene = ReplayScene(
+			replays[self.menu_state.replay],
+			self.secret_inputs
+		)
+	elseif e.input == "up" or e.scancode == "up" then
+		self:changeOption(-1)
+		self.das_up = true
+		self.das_down = nil
+	elseif e.input == "down" or e.scancode == "down" then
+		self:changeOption(1)
+		self.das_down = true
+		self.das_up = nil
+	elseif e.input == "menu_back" or e.scancode == "delete" or e.scancode == "backspace" then
+		scene = TitleScene()
+	elseif e.input then
+		self.secret_inputs[e.input] = true
+	end
+end
+
+function ReplaySelectScene:onInputRelease(e)
+	if e.input == "up" or e.scancode == "up" then
+		self.das_up = nil
+	elseif e.input == "down" or e.scancode == "down" then
+		self.das_down = nil
+	elseif e.input then
+		self.secret_inputs[e.input] = false
+	end
+end
+
+function ReplaySelectScene:changeOption(rel)
+	local len = table.getn(replays)
+	self.menu_state.replay = Mod1(self.menu_state.replay + rel, len)
+	playSE("cursor")
+end
+
+return ReplaySelectScene

--- a/scene/title.lua
+++ b/scene/title.lua
@@ -5,6 +5,7 @@ TitleScene.restart_message = false
 
 local main_menu_screens = {
 	ModeSelectScene,
+	ReplaySelectScene,
 	SettingsScene,
 	CreditsScene,
 	ExitScene,

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -360,21 +360,41 @@ function GameMode:onGameOver()
 	if self.game_over_frames < animation_length then
 		-- Show field for a bit, then fade out.
 		alpha = math.pow(2048, self.game_over_frames/animation_length - 1)
-	elseif self.game_over_frames < 2 * animation_length then
-		-- Keep field hidden for a short time, then pop it back in (for screenshots).
+	elseif self.game_over_frames == animation_length then
 		alpha = 1
-	elseif self.game_over_frames == 2 * animation_length then
 		-- Save replay.
 		local replay = {}
 		replay["inputs"] = self.replay_inputs
 		replay["pieces"] = self.replay_pieces
 		replay["mode"] = self.name
 		replay["ruleset"] = self.ruleset.name
+		replay["timer"] = self.frames
+		replay["score"] = self.score
+		replay["level"] = self.level
+		replay["lines"] = self.lines
+		replay["gamesettings"] = config.gamesettings
+		replay["timestamp"] = os.time()
 		if love.filesystem.getInfo("replays") == nil then
 			love.filesystem.createDirectory("replays")
 		end
-		local replay_number = table.getn(love.filesystem.getDirectoryItems("replays")) + 1
-		love.filesystem.write("replays/"..replay_number..".lua", binser.serialize(replay))
+		local replay_files = love.filesystem.getDirectoryItems("replays")
+		-- Select replay filename that doesn't collide with an existing one
+		local replay_number = 0
+		local collision = true
+		while collision do
+			collision = false
+			replay_number = replay_number + 1
+			for key, file in pairs(replay_files) do
+				if file == replay_number..".rply" then
+					collision = true
+					break
+				end
+			end
+		end
+		love.filesystem.write("replays/"..replay_number..".rply", binser.serialize(replay))
+	elseif self.game_over_frames < 2 * animation_length then
+		-- Keep field hidden for a short time, then pop it back in (for screenshots).
+		alpha = 1
 	end
 	love.graphics.setColor(0, 0, 0, alpha)
 	love.graphics.rectangle(

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -102,10 +102,6 @@ function GameMode:getSkin()
 end
 
 function GameMode:initialize(ruleset)
-	local dummy_entry = {}
-	dummy_entry["inputs"] = {}
-	dummy_entry["frames"] = 0
-	self.replay_inputs[#self.replay_inputs + 1] = dummy_entry
 	-- generate next queue
 	self.used_randomizer = (
 		table.equalvalues(
@@ -145,8 +141,11 @@ function GameMode:update(inputs, ruleset)
 	   or self.prev_inputs["rotate_left2"] ~= inputs["rotate_left2"] or self.prev_inputs["rotate_right2"] ~= inputs["rotate_right2"] then
 		-- insert new inputs into replay inputs table
 		local new_inputs = {}
-		new_inputs["inputs"] = inputs
-		new_inputs["frames"] = 0
+		new_inputs["inputs"] = {}
+		new_inputs["frames"] = 1
+		for key, value in pairs(inputs) do
+			new_inputs["inputs"][key] = value
+		end
 		self.replay_inputs[#self.replay_inputs + 1] = new_inputs
 	else
 		-- add 1 to input frame counter


### PR DESCRIPTION
Replays are saved in Lua's save directory in a "replays" folder with filenames 1.rply, 2.rply etc., and have a new option on the main menu.
The replay list menu is a list that shows replays--newest at the top--with date, mode, ruleset, timer, level. It has DAS, and left/right skip forward/back by 9.
When playing a game, inputs and pieces are each saved to a table. Inputs are paired with a number that records how many frames those inputs were held for. When the game ends, the two tables are saved to a replay file along with meta information about the game.
When replaying a game, the randomizer and user's inputs replaced by the replay file, and a new replay is not saved on game over. Otherwise, the game class works as normal.

Future improvements:
- load configuration from replay file so that the replay still plays properly even if the user's configuration has changed (currently saved to replay file, but ignored when replayed)
- implement a mode/ruleset/Cambridge replay versioning system so that developers and modders can indicate when a new version breaks old replays
- improve the replay list menu
- option to turn replay saving off
- error handling for file I/O
- bugfixes