### PR TITLE
Cursor menu controls and some replay fixes and ruleset synchroes variable.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -64,7 +64,6 @@ right_clicked_before = false
 function getScaledPos(cursor_x, cursor_y)
 	local screen_x, screen_y = love.graphics.getDimensions()
 	local scale_factor = math.min(screen_x / 640, screen_y / 480)
-	love.graphics.print((cursor_x - (screen_x - scale_factor * 640) / 2)/scale_factor..(cursor_y - (screen_y - scale_factor * 480) / 2)/scale_factor)
 	return (cursor_x - (screen_x - scale_factor * 640) / 2)/scale_factor, (cursor_y - (screen_y - scale_factor * 480) / 2)/scale_factor
 end
 

--- a/main.lua
+++ b/main.lua
@@ -58,7 +58,34 @@ function initModules()
 	table.sort(rulesets, function(a,b)
 	return tostring(a.name):gsub("%d+",padnum) < tostring(b.name):gsub("%d+",padnum) end)
 end
+left_clicked_before = false
+right_clicked_before = false
+-- For when mouse controls are part of menu controls
+function getScaledPos(cursor_x, cursor_y)
+	local screen_x, screen_y = love.graphics.getDimensions()
+	local scale_factor = math.min(screen_x / 640, screen_y / 480)
+	love.graphics.print((cursor_x - (screen_x - scale_factor * 640) / 2)/scale_factor..(cursor_y - (screen_y - scale_factor * 480) / 2)/scale_factor)
+	return (cursor_x - (screen_x - scale_factor * 640) / 2)/scale_factor, (cursor_y - (screen_y - scale_factor * 480) / 2)/scale_factor
+end
 
+--Interpolates in a smooth fashion.
+function interpolateListHeight(input, from)
+	if config.gamesettings["smooth_scroll"] == 2 then
+		return from
+	end
+	if from > input then
+		input = input + (from - input) / 4
+		if input > from - 0.02 then
+			input = from
+		end
+	elseif from < input then
+		input = input + (from - input) / 4
+		if input < from + 0.02 then
+			input = from
+		end
+	end
+	return input
+end
 function love.draw()
 	love.graphics.setCanvas(GLOBAL_CANVAS)
 	love.graphics.clear()
@@ -85,6 +112,7 @@ function love.draw()
 			"fps - " .. version, 0, 460, 635, "right"
 		)
 	end
+	getScaledPos(love.mouse.getPosition())
 	
 	love.graphics.pop()
 		
@@ -338,6 +366,7 @@ function love.run()
 			end
 			time_accumulator = time_accumulator - frame_duration
 		end
+		if love.mouse then left_clicked_before = love.mouse.isDown(1) right_clicked_before = love.mouse.isDown(2) end
 		last_time = love.timer.getTime()
 	end
 end

--- a/scene/credits.lua
+++ b/scene/credits.lua
@@ -19,8 +19,8 @@ function CreditsScene:update()
     if love.window.hasFocus() then
         self.frames = self.frames + 1
     end
-    if self.frames >= 2100 * self.scroll_speed then
-        playSE("mode_decide")
+    if self.frames >= 2100 * self.scroll_speed or (love.mouse.isDown(1) and not left_clicked_before) then
+        if(not (love.mouse.isDown(1) and not left_clicked_before)) then playSE("mode_decide") end
         scene = TitleScene()
         switchBGM(nil)
     elseif self.frames == math.floor(1950 * self.scroll_speed) then

--- a/scene/game_config.lua
+++ b/scene/game_config.lua
@@ -19,6 +19,7 @@ ConfigScene.options = {
 	{"das_last_key", "DAS Last Key", false, {"Off", "On"}},
 	{"buffer_lock", "Buffer Drop Type", false, {"Off", "Hold", "Tap"}},
 	{"synchroes_allowed", "Synchroes", false, {"Per ruleset", "On", "Off"}},
+	{"smooth_scroll", "Smooth Scrolling", false, {"On", "Off"}},
 	{"sfx_volume", "SFX", true, "sfxSlider"},
 	{"bgm_volume", "BGM", true, "bgmSlider"},
 }
@@ -39,8 +40,25 @@ function ConfigScene:new()
 end
 
 function ConfigScene:update()
-	self.sfxSlider:update()
-	self.bgmSlider:update()
+	local x, y = getScaledPos(love.mouse.getPosition())
+	self.sfxSlider:update(x,y)
+	self.bgmSlider:update(x,y)
+	--#region Mouse
+	if not love.mouse.isDown(1) or left_clicked_before then return end
+	for i, option in ipairs(ConfigScene.options) do
+		if not option[3] then
+		for j, setting in ipairs(option[4]) do
+			if x > 100 + 110 * j and x < 200 + 110 * j then
+				if y > 100 + i * 20 and y < 120 + i * 20 then
+					self.main_menu_state = math.floor((y - 280) / 20)
+					playSE("cursor_lr")
+					config.gamesettings[option[1]] = Mod1(j, #option[4])
+				end
+			end
+			-- local option = ConfigScene.options[self.highlight]
+		end end
+	end
+	--#endregion
 end
 
 function ConfigScene:render()
@@ -53,6 +71,13 @@ function ConfigScene:render()
 
 	love.graphics.setFont(font_3x5_4)
 	love.graphics.print("GAME SETTINGS", 80, 40)
+	-- love.graphics.setColor(1, 1, 1, 0.5)
+	-- love.graphics.rectangle("fill", 580, 40, 60, 35)
+	-- love.graphics.setColor(1, 1, 1, 1)
+	-- love.graphics.setFont(font_3x5_3)
+	-- love.graphics.printf("SAVE", 580, 40, 60, "center")
+	-- love.graphics.setFont(font_3x5)
+	-- love.graphics.printf("(MOUSE ONLY)", 580, 62, 60, "center")
 
 	--Lazy check to see if we're on the SFX or BGM slider. Probably will need to be rewritten if more options get added.
 	love.graphics.setColor(1, 1, 1, 0.5)
@@ -112,7 +137,7 @@ function ConfigScene:onInputPress(e)
 			local option = ConfigScene.options[self.highlight]
 			config.gamesettings[option[1]] = Mod1(config.gamesettings[option[1]]+1, #option[4])
 		else
-			sld = self[self.options[self.highlight][4]]
+			local sld = self[self.options[self.highlight][4]]
 			sld.value = math.max(sld.min, math.min(sld.max, (sld:getValue() + 5) / (sld.max - sld.min)))
 			sld:update()
 			playSE("cursor")

--- a/scene/game_config.lua
+++ b/scene/game_config.lua
@@ -93,7 +93,8 @@ function ConfigScene:render()
 			love.graphics.setColor(1, 1, 1, 1)
 			love.graphics.printf(option[2], 40, 100 + i * 20, 150, "left")
 			for j, setting in ipairs(option[4]) do
-				love.graphics.setColor(1, 1, 1, config.gamesettings[option[1]] == j and 1 or 0.5)
+				local b = CursorHighlight(100 + 110 * j, 100 + i * 20,100,20)
+				love.graphics.setColor(1, 1, b, config.gamesettings[option[1]] == j and 1 or 0.5)
 				love.graphics.printf(setting, 100 + 110 * j, 100 + i * 20, 100, "center")
 			end
 		end

--- a/scene/input_config.lua
+++ b/scene/input_config.lua
@@ -48,6 +48,8 @@ function ConfigScene:render()
     love.graphics.setFont(font_3x5_3)
 	love.graphics.setColor(1, 1, 1, 1)
 	for i, screen in pairs(menu_screens) do
+		local b = CursorHighlight(80,120 + 50 * i,200,50)
+		love.graphics.setColor(1,1,b,1)
 		love.graphics.printf(screen.title, 80, 120 + 50 * i, 200, "left")
     end
 end

--- a/scene/input_config.lua
+++ b/scene/input_config.lua
@@ -16,7 +16,17 @@ function ConfigScene:new()
     })
 end
 
-function ConfigScene:update() end
+function ConfigScene:update()
+	if not love.mouse.isDown(1) or left_clicked_before then return end
+	local mouse_x, mouse_y = getScaledPos(love.mouse.getPosition())
+    if mouse_x > 75 and mouse_x < 275 then
+        if mouse_y > 170 and mouse_y < 270 then
+            self.menu_state = math.floor((mouse_y - 120) / 50)
+            playSE("main_decide")
+            scene = menu_screens[self.menu_state]()
+        end
+    end
+end
 
 function ConfigScene:render()
     love.graphics.setColor(1, 1, 1, 1)

--- a/scene/mode_select.lua
+++ b/scene/mode_select.lua
@@ -111,33 +111,43 @@ function ModeSelectScene:render()
 	elseif self.menu_state.select == "ruleset" then
 		love.graphics.setColor(1, 1, 1, 0.25)
 	end
-	love.graphics.rectangle("fill", 20, 258, 240, 22)
+	self.menu_mode_height = interpolateListHeight(self.menu_mode_height / 20, self.menu_state.mode) * 20
+	self.menu_ruleset_height = interpolateListHeight(self.menu_ruleset_height / 20, self.menu_state.ruleset) * 20
+	love.graphics.rectangle("fill", 20, 258 + (self.menu_state.mode * 20) - self.menu_mode_height, 240, 22)
 
 	if self.menu_state.select == "mode" then
 		love.graphics.setColor(1, 1, 1, 0.25)
 	elseif self.menu_state.select == "ruleset" then
 		love.graphics.setColor(1, 1, 1, 0.5)
 	end
-	love.graphics.rectangle("fill", 340, 258, 200, 22)
+	love.graphics.rectangle("fill", 340, 258 + (self.menu_state.ruleset * 20) - self.menu_ruleset_height, 200, 22)
 
 	love.graphics.setColor(1, 1, 1, 1)
 
-	self.menu_mode_height = interpolateListHeight(self.menu_mode_height / 20, self.menu_state.mode) * 20
-	self.menu_ruleset_height = interpolateListHeight(self.menu_ruleset_height / 20, self.menu_state.ruleset) * 20
 	love.graphics.setFont(font_3x5_2)
 	for idx, mode in pairs(game_modes) do
 		if(idx >= self.menu_mode_height / 20-10 and idx <= self.menu_mode_height / 20+10) then
-			love.graphics.setColor(1,1,1,FadeoutAtEdges((-self.menu_mode_height) + 20 * idx, 180, 20))
+			local b = CursorHighlight(0,(260 - self.menu_mode_height) + 20 * idx,320,20)
+			love.graphics.setColor(1,1,b,FadeoutAtEdges((-self.menu_mode_height) + 20 * idx, 180, 20))
 			love.graphics.printf(mode.name, 40, (260 - self.menu_mode_height) + 20 * idx, 200, "left")
 		end
 	end
 	for idx, ruleset in pairs(rulesets) do
 		if(idx >= self.menu_ruleset_height / 20-10 and idx <= self.menu_ruleset_height / 20+10) then
-			love.graphics.setColor(1,1,1,FadeoutAtEdges(-self.menu_ruleset_height + 20 * idx, 180, 20))
+			local b = CursorHighlight(320,(260 - self.menu_ruleset_height) + 20 * idx,320,20)
+			love.graphics.setColor(1,1,b,FadeoutAtEdges(-self.menu_ruleset_height + 20 * idx, 180, 20))
 			love.graphics.printf(ruleset.name, 360, (260 - self.menu_ruleset_height) + 20 * idx, 160, "left")
 		end
 	end
 	love.graphics.setColor(1,1,1,1)
+end
+function CursorHighlight(x,y,w,h)
+	local mouse_x, mouse_y = getScaledPos(love.mouse.getPosition())
+	if mouse_x > x and mouse_x < x+w and mouse_y > y and mouse_y < y+h then
+		return 0
+	else
+		return 1
+	end
 end
 function FadeoutAtEdges(input, edge_distance, edge_width)
 	if input < 0 then

--- a/scene/replay.lua
+++ b/scene/replay.lua
@@ -6,6 +6,9 @@ ReplayScene.title = "Replay"
 
 function ReplayScene:new(replay, game_mode, ruleset)
 	config.gamesettings = replay["gamesettings"]
+	config.das = replay["delayed_auto_shift"]
+	config.arr = replay["auto_repeat_rate"]
+	config.dcd = replay["das_cut_delay"]
 	love.math.setRandomSeed(replay["random_low"], replay["random_high"])
 	love.math.setRandomState(replay["random_state"])
 	self.retry_replay = replay

--- a/scene/replay.lua
+++ b/scene/replay.lua
@@ -6,9 +6,10 @@ ReplayScene.title = "Replay"
 
 function ReplayScene:new(replay, game_mode, ruleset)
 	config.gamesettings = replay["gamesettings"]
-	config.das = replay["delayed_auto_shift"]
-	config.arr = replay["auto_repeat_rate"]
-	config.dcd = replay["das_cut_delay"]
+	if replay["delayed_auto_shift"] then config.das = replay["delayed_auto_shift"] end
+	if replay["auto_repeat_rate"] then config.arr = replay["auto_repeat_rate"] end
+
+	if replay["das_cut_delay"] then config.dcd = replay["das_cut_delay"] end
 	love.math.setRandomSeed(replay["random_low"], replay["random_high"])
 	love.math.setRandomState(replay["random_state"])
 	self.retry_replay = replay

--- a/scene/replay_select.lua
+++ b/scene/replay_select.lua
@@ -55,6 +55,10 @@ function ReplaySelectScene:update()
 
 	local mouse_x, mouse_y = getScaledPos(love.mouse.getPosition())
 	if love.mouse.isDown(1) and not left_clicked_before then
+		if self.display_error then
+			scene = TitleScene()
+			return
+		end
 		self.auto_menu_offset = math.floor((mouse_y - 260)/20)
 		if self.auto_menu_offset == 0 then
 			self:startReplay()
@@ -136,7 +140,7 @@ function ReplaySelectScene:render()
 	love.graphics.setColor(1, 1, 1, 1)
 	love.graphics.setFont(font_3x5_2)
 	for idx, replay in ipairs(replays) do
-		if(idx >= self.height_offset/20-9.5 and idx <= self.height_offset/20+9.5) then
+		if(idx >= self.height_offset/20-10 and idx <= self.height_offset/20+10) then
 			local display_string = os.date("%c", replay["timestamp"]).." - "..replay["mode"].." - "..replay["ruleset"]
 			if replay["level"] ~= nil then
 				display_string = display_string.." - Level: "..replay["level"]
@@ -147,6 +151,7 @@ function ReplaySelectScene:render()
 			if #display_string > 75 then
 				display_string = display_string:sub(1, 75) .. "..."
 			end
+			love.graphics.setColor(1,1,CursorHighlight(0, (260 - self.height_offset) + 20 * idx, 640, 20),FadeoutAtEdges((-self.height_offset) + 20 * idx, 180, 20))
 			love.graphics.printf(display_string, 6, (260 - self.height_offset) + 20 * idx, 640, "left")
 		end
 	end

--- a/scene/settings.lua
+++ b/scene/settings.lua
@@ -25,7 +25,17 @@ function SettingsScene:new()
     })
 end
 
-function SettingsScene:update() end
+function SettingsScene:update()
+	if not love.mouse.isDown(1) or left_clicked_before then return end
+	local mouse_x, mouse_y = getScaledPos(love.mouse.getPosition())
+    if mouse_x > 75 and mouse_x < 275 then
+        if mouse_y > 170 and mouse_y < 320 then
+            self.menu_state = math.floor((mouse_y - 120) / 50)
+            playSE("main_decide")
+            scene = menu_screens[self.menu_state]()
+        end
+    end
+end
 
 function SettingsScene:render()
     love.graphics.setColor(1, 1, 1, 1)

--- a/scene/settings.lua
+++ b/scene/settings.lua
@@ -57,6 +57,8 @@ function SettingsScene:render()
     love.graphics.setFont(font_3x5_3)
 	love.graphics.setColor(1, 1, 1, 1)
 	for i, screen in pairs(menu_screens) do
+		local b = CursorHighlight(80,120 + 50 * i,200,50)
+		love.graphics.setColor(1,1,b,1)
 		love.graphics.printf(screen.title, 80, 120 + 50 * i, 200, "left")
     end
 end

--- a/scene/title.lua
+++ b/scene/title.lua
@@ -129,6 +129,8 @@ function TitleScene:render()
 
 	love.graphics.setColor(1, 1, 1, 1)
 	for i, screen in pairs(main_menu_screens) do
+		local b = CursorHighlight(40,280 + 20 * i,120,20)
+		love.graphics.setColor(1,1,b,1)
 		love.graphics.printf(screen.title, 40, 280 + 20 * i, 120, "left")
 	end
 end

--- a/scene/title.lua
+++ b/scene/title.lua
@@ -58,6 +58,15 @@ function TitleScene:update()
 	if self.frames < 125 then self.y_offset = self.frames
 	elseif self.frames < 185 then self.y_offset = 125
 	else self.y_offset = 310 - self.frames end
+	local mouse_x, mouse_y = getScaledPos(love.mouse.getPosition())
+	if not love.mouse.isDown(1) or left_clicked_before then return end
+	if mouse_x > 40 and mouse_x < 160 then
+		if mouse_y > 300 and mouse_y < 400 then
+			self.main_menu_state = math.floor((mouse_y - 280) / 20)
+			playSE("main_decide")
+			scene = main_menu_screens[self.main_menu_state]()
+		end
+	end
 end
 
 local block_offsets = {

--- a/scene/tuning.lua
+++ b/scene/tuning.lua
@@ -27,9 +27,10 @@ function TuningScene:new()
 end
 
 function TuningScene:update()
-    self.dasSlider:update()
-	self.arrSlider:update()
-	self.dcdSlider:update()
+	local x, y = getScaledPos(love.mouse.getPosition())
+    self.dasSlider:update(x,y)
+	self.arrSlider:update(x,y)
+	self.dcdSlider:update(x,y)
 end
 
 function TuningScene:render()

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -135,6 +135,9 @@ function GameMode:saveReplay()
 	replay["lines"] = self.lines
 	replay["gamesettings"] = config.gamesettings
 	replay["secret_inputs"] = self.secret_inputs
+	replay["delayed_auto_shift"] = config.das
+	replay["auto_repeat_rate"] = config.arr
+	replay["das_cut_delay"] = config.dcd
 	replay["timestamp"] = os.time()
 	if love.filesystem.getInfo("replays") == nil then
 		love.filesystem.createDirectory("replays")

--- a/tetris/rulesets/arika_ti.lua
+++ b/tetris/rulesets/arika_ti.lua
@@ -6,6 +6,7 @@ local ARS = Ruleset:extend()
 ARS.name = "Ti-ARS"
 ARS.hash = "ArikaTI"
 
+ARS.synchroes = true
 -- Component functions.
 
 function ARS:attemptWallkicks(piece, new_piece, rot_dir, grid)

--- a/tetris/rulesets/ruleset.lua
+++ b/tetris/rulesets/ruleset.lua
@@ -255,7 +255,7 @@ function Ruleset:processPiece(
 	drop_locked, hard_drop_locked,
 	hard_drop_enabled, additive_gravity, classic_lock
 )
-	local synchroes_allowed = ({not self.world, true, false})[config.gamesettings.synchroes_allowed]
+	local synchroes_allowed = ({not self.world or self.synchroes, true, false})[config.gamesettings.synchroes_allowed]
 
 	if synchroes_allowed then
 		self:rotatePiece(inputs, piece, grid, prev_inputs, false)

--- a/tetris/rulesets/ti_srs.lua
+++ b/tetris/rulesets/ti_srs.lua
@@ -6,6 +6,7 @@ local SRS = Ruleset:extend()
 SRS.name = "Ti-World"
 SRS.hash = "StandardTI"
 SRS.world = true
+SRS.synchroes = true
 SRS.colourscheme = {
 	I = "C",
 	L = "O",


### PR DESCRIPTION
This pull request contains not only mouse controls
![image](https://user-images.githubusercontent.com/76738929/156865625-c702ffec-e985-4de0-8eef-8876e57a637e.png)
as shown here, but also fixes some replay oversights (this does not fix the existing ones).

![image](https://user-images.githubusercontent.com/76738929/156865857-3903784c-109e-45ca-83b4-b469b17ef00a.png)
You can also add synchroes variable to a ruleset to mean that this ruleset has synchroes on despite it being world rule or not, as you can see there, though that's still can be turned off in game settings.