### PR TITLE
Patch standard.lua to prevent midair lock

### DIFF
--- a/tetris/rulesets/standard.lua
+++ b/tetris/rulesets/standard.lua
@@ -93,6 +93,8 @@ function SRS:onPieceMove(piece, grid)
 		if piece.manipulations >= SRS.MANIPULATIONS_MAX then
 			piece.locked = true
 		end
+	else
+		piece.locked = false
 	end
 end
 


### PR DESCRIPTION
Once piece's manipulations counter reaches 15, `onPieceRotate` function will set `piece.locked` to true, then piece moves, resulting in piece locking in midair.
This patch effectively stops this bug occuring on one ruleset.

Before this patch:
![image](https://github.com/MillaBasset/cambridge/assets/76738929/846f0cd7-170f-4aeb-b4d1-61527fb85c9b)
After this patch:
![image](https://github.com/MillaBasset/cambridge/assets/76738929/780f29d3-1038-4b32-ba37-0fa0519dc2f4)